### PR TITLE
Added check to lock mouse only while League is the front-running window.

### DIFF
--- a/src/ContentView.swift
+++ b/src/ContentView.swift
@@ -35,6 +35,7 @@ struct ContentView: View {
                 }
             }.padding(.bottom)
             Toggle("Pause", isOn: $appState.pause).toggleStyle(.switch)
+            Toggle("League Only", isOn: $appState.leagueonly).toggleStyle(.switch)
         }.padding(30).padding(.top, -5).frame(width: 340)
     }
 }

--- a/src/mouselockApp.swift
+++ b/src/mouselockApp.swift
@@ -27,6 +27,9 @@ class AppState: ObservableObject {
     @Published var pause: Bool = UserDefaults.standard.bool(forKey: "pause") {
         didSet {UserDefaults.standard.set(self.pause, forKey: "pause")}
     };
+    @Published var leagueonly: Bool = UserDefaults.standard.bool(forKey: "leagueonly") {
+        didSet {UserDefaults.standard.set(self.leagueonly, forKey: "leagueonly")}
+    };
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -49,7 +52,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if (AppState.shared.pause) {
                 return;
             }
-            
+
+            // Is league running?
+            if (AppState.shared.leagueonly) {
+                if (NSWorkspace().frontmostApplication?.bundleIdentifier != "com.riotgames.LeagueofLegends.GameClient") {
+                    return;
+                }
+            }
+
             // check controlkeys
             let controlkey = AppState.shared.controlkeys
                 .filter {!$0.isWhitespace}


### PR DESCRIPTION
Sometimes you only need to lock the mouse to League, but unlock while you're cmd+tabbed.